### PR TITLE
Add .parcerlrc so images are seen in the parcel server

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,10 @@
+{
+    extends: ["@parcel/config-default"],
+    reporters: ["...", "parcel-reporter-static-files-copy"],
+    packagers: {
+        // ".js": "@parcel/packager-raw-url"
+    },
+    transformers: {
+        "manifest.json": ["@parcel/transformer-webmanifest"]
+    },
+}


### PR DESCRIPTION
Hi!

Something I noticed while working on my forked version of the parcel-update branch is that images aren't included during the build process. This means that you cannot see any images located in the `images` directory and its subsecuent children.

After some investigating I noticed that in the `package.json` there exists the parcel plugins neccesary to make this work, but they aren't implemented; so I decided to fix that. Here's the `.parcelrc` I made:

```JSON5
{
    extends: ["@parcel/config-default"],
    reporters: ["...", "parcel-reporter-static-files-copy"],
    packagers: {
        // ".js": "@parcel/packager-raw-url"
    },
    transformers: {
        "manifest.json": ["@parcel/transformer-webmanifest"]
    },
}
```

The only plugin I didn't add was `@parcel/packager-raw-url` and its therefore commented. I couldn't find anywhere information on what this plugin does but it seemed to break the skud pai sho code when I tried running it. I still included it in case you wish to modify it or know how it works.